### PR TITLE
Update BackOfficeHost URL for production environment

### DIFF
--- a/Oazis.Api/appsettings.Production.json
+++ b/Oazis.Api/appsettings.Production.json
@@ -51,7 +51,7 @@
       },
       "Security": {
         "AllowConcurrentLogins": false,
-        "BackOfficeHost": "https://localhost:44370/"
+        "BackOfficeHost": "https://www.oazisvendeglo.hu/"
       }
     }
   },


### PR DESCRIPTION
Changed the BackOfficeHost URL in appsettings.Production.json from https://localhost:44370/ to https://www.oazisvendeglo.hu/ to ensure the application uses the correct host in a production environment.